### PR TITLE
Linux changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+*.o
+*.obj
+a.out
+wla_dx/wlab/wlab
+wla_dx/wlalink/wlalink
+wla_dx/wla-65816
+libs/libc_c.asm
+libs/libm_c.asm
+*.sfc
+*.smc
+*.sym
+tcc-65816/816-tcc
+tcc-65816/config.h
+tcc-65816/config.mak

--- a/wla_dx/makefiles/makefile.unix.65816
+++ b/wla_dx/makefiles/makefile.unix.65816
@@ -2,7 +2,8 @@
 CC=gcc
 LD=gcc
 
-CFLAGS?= -c -O2 -ansi -pedantic -Wall -g
+CFLAGS += -c -ansi
+CFLAGS ?= -O2 -pedantic -Wall -g
 LDFLAGS = -lm
 WLAFLAGS = $(CFLAGS) -DUNIX -DW65816
 

--- a/wla_dx/wlab/makefile
+++ b/wla_dx/wlab/makefile
@@ -2,7 +2,8 @@
 CC?=egcs
 LD?=egcs
 
-CFLAGS?= -c -ansi -O3 -pedantic -Wall
+CFLAGS += -c -ansi
+CFLAGS ?= -O3 -pedantic -Wall
 LDFLAGS = 
 
 CFILES = main.c

--- a/wla_dx/wlalink/makefile
+++ b/wla_dx/wlalink/makefile
@@ -2,7 +2,8 @@
 CC=gcc
 LD=gcc
 
-CFLAGS?= -c -g -Wall -O2 -DPREFIX=\"$(PREFIX)\"
+CFLAGS += -c -DPREFIX=\"$(PREFIX)\"
+CFLAGS ?= -g -Wall -O2
 LDFLAGS =
 
 CFILES = main.c memory.c parse.c files.c check.c analyze.c write.c compute.c discard.c listfile.c


### PR DESCRIPTION
It's common for Linux systems to have CFLAGS defined in the environment. Separating the required-to-build options from the optional defaults allows wla to build.

The .gitignore was missing, add it for cleanliness.